### PR TITLE
重构docker文件，修改scheduler运行方式与docker定时运行

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /app
 # 复制项目文件到容器中
 COPY . /app
 
+ENV CRON_SIGNIN='30 9 * * *'
+ENV TZ=Asia/Shanghai
+
 # 安装依赖
 RUN pip install --no-cache-dir -r requirements.txt
 
@@ -16,4 +19,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 
 # 运行主程序
-CMD ["python", "main.py"]
+CMD ["python", "task_scheduler.py"]

--- a/README.md
+++ b/README.md
@@ -287,8 +287,14 @@ ql repo https://github.com/mxyooR/Kuro-autosignin.git "ql_main.py" "" "log|game_
    git clone https://github.com/mxyooR/Kuro-autosignin.git
    cd Kuro-autosignin
    ```
+
+2. **修改定时信息**（可选）：\
+   如果需要修改定时任务，可以在 `Dockerfile` 中的 `ENV CRON_SIGNIN` 行进行修改，格式为标准的 cron 表达式。例如，设置为每天早上9:30：
+    ```dockerfile
+    ENV CRON_SIGNIN="30 9 * * *"
+    ```
   
-2. **构建镜像**：
+3. **构建镜像**：
    ```bash
    docker build -t kuro-autosignin .
    ```
@@ -308,19 +314,10 @@ ql repo https://github.com/mxyooR/Kuro-autosignin.git "ql_main.py" "" "log|game_
 ### 使用 Docker Compose（可选）
 如果你希望更方便地管理容器，可以使用 Docker Compose。
 
-1. **创建 `docker-compose.yml` 文件**：
+1. **修改 `docker-compose.yml` 文件**：
+   与上文Dockerfile文件相同，此文件中的 `CRON_SIGNIN` 环境变量可以根据需要修改。
    ```yaml
-   version: '3.8'
-   services:
-     kuro-autosignin:
-       build: .
-       container_name: kuro-autosignin-container
-       environment:
-         - CRON_SIGNIN=30 9 * * *
-         - TZ=Asia/Shanghai
-       volumes:
-         - ./config:/app/config
-       restart: unless-stopped
+   - CRON_SIGNIN=30 9 * * *
    ```
 
 2. **启动容器**：

--- a/README.md
+++ b/README.md
@@ -299,12 +299,12 @@ ql repo https://github.com/mxyooR/Kuro-autosignin.git "ql_main.py" "" "log|game_
    docker build -t kuro-autosignin .
    ```
 
-3. **运行容器**：
+4. **运行容器**：
    ```bash
    docker run -d --name kuro-autosignin-container kuro-autosignin
    ```
 
-4. **查看日志**：
+5. **查看日志**：
    ```bash
    docker logs kuro-autosignin-container
    ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  kuro-sign:
+    build: .
+    container_name: kuro
+    environment:
+      - CRON_SIGNIN=30 9 * * *
+      - TZ=Asia/Shanghai
+    volumes:
+      - ./config:/app/config
+    restart: unless-stopped

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests
 httpx
-schedule
+crontab
 loguru
 pytz
 pyyaml

--- a/task_scheduler.py
+++ b/task_scheduler.py
@@ -1,16 +1,40 @@
-import schedule
+import os
 import time
-import random
-from main import main
+import datetime
+from log import setup_logger, log_info
+import logging
 
-def sign_in_with_random_delay():
-    delay = random.randint(0, 600)  
-    time.sleep(delay)
+from crontab import CronTab
+
+setup_logger(log_level=logging.INFO)
+time_format = "%Y-%m-%d %H:%M:%S"
+
+def main():
+    log_info("DOCKER定时模式已启用")
+    env = os.environ
+    cron_signin = env["CRON_SIGNIN"]
+    cron = CronTab(cron_signin, loop=True, random_seconds=True)
+
+    def next_run_time():
+        nt = datetime.datetime.now().strftime(time_format)
+        delayt = cron.next(default_utc=False)
+        nextrun = datetime.datetime.now() + datetime.timedelta(seconds=delayt)
+        nextruntime = nextrun.strftime(time_format)
+        log_info(f"当前时间: {nt}")
+        log_info(f"下次运行时间: {nextruntime}")
+
+    def sign():
+        log_info("开始签到")
+        os.system("python ./main.py")
+
+    sign()
+    next_run_time()
+    while True:
+        ct = cron.next(default_utc=False)
+        time.sleep(ct)
+        sign()
+        next_run_time()
+
+
+if __name__ == '__main__':
     main()
-
-# 每天7点到7点10分之间开始
-schedule.every().day.at("07:00").do(sign_in_with_random_delay)
-
-while True:
-    schedule.run_pending()
-    time.sleep(1)


### PR DESCRIPTION
此前的Docker运行方式无法正确实现定时运行，本PR仿照隔壁的docker运行方式完全重构了此文件，使用`crontab`替代了`schedule`库，并修复了Dockerfile与docker-compose文件的定时功能，经本地测试直接运行`docker compose up -d`即可实现定时运行功能
<img width="514" height="110" alt="time schedule screenshot" src="https://github.com/user-attachments/assets/9b8102d7-a983-400b-84d7-6206ea58dcdb" />