### PR TITLE
给discord消息推送添加SSL验证控制与http代理选项

### DIFF
--- a/config/push.ini.example
+++ b/config/push.ini.example
@@ -98,3 +98,5 @@ key=你的qmsg酱key
 webhook=https://discord.com/api/webhooks/your_channel_id_xxxxxx/your_webhook_token_xxxxxx
 #给discord推送启用代理，取消注释即可启用
 #http_proxy=127.0.0.1:1080
+#添加SSL控制选项
+verify_ssl=false

--- a/config/push.ini.example
+++ b/config/push.ini.example
@@ -96,3 +96,5 @@ key=你的qmsg酱key
 # Discord Channel Webhook
 [discord]
 webhook=https://discord.com/api/webhooks/your_channel_id_xxxxxx/your_webhook_token_xxxxxx
+#给discord推送启用代理，取消注释即可启用
+#http_proxy=127.0.0.1:1080

--- a/push.py
+++ b/push.py
@@ -399,7 +399,9 @@ def discord(send_title, push_message):
 
         http_proxy = cfg.get('discord', 'http_proxy', fallback=None)               
         session = get_new_session_use_proxy(http_proxy) if http_proxy else http
+        verify_ssl = cfg.getboolean('discord', 'verify_ssl', fallback=True)
         rep = session.post(
+            verify=verify_ssl,
             url=f'{cfg.get("discord", "webhook")}',
             headers={"Content-Type": "application/json; charset=utf-8"},
             json={

--- a/push.py
+++ b/push.py
@@ -59,7 +59,7 @@ def get_new_session(**kwargs):
         http_client.mount('https://', HTTPAdapter(max_retries=10))
         # 对于 requests，从 kwargs 中提取 proxies
         if 'proxies' in kwargs:
-        http_client.proxies.update(kwargs['proxies'])
+            http_client.proxies.update(kwargs['proxies'])
     return http_client
 
 

--- a/push.py
+++ b/push.py
@@ -57,6 +57,9 @@ def get_new_session(**kwargs):
         http_client = requests.Session()
         http_client.mount('http://', HTTPAdapter(max_retries=10))
         http_client.mount('https://', HTTPAdapter(max_retries=10))
+        # 对于 requests，从 kwargs 中提取 proxies
+        if 'proxies' in kwargs:
+        http_client.proxies.update(kwargs['proxies'])
     return http_client
 
 
@@ -394,7 +397,9 @@ def discord(send_title, push_message):
     try:
         import pytz
 
-        rep = http.post(
+        http_proxy = cfg.get('discord', 'http_proxy', fallback=None)               
+        session = get_new_session_use_proxy(http_proxy) if http_proxy else http
+        rep = session.post(
             url=f'{cfg.get("discord", "webhook")}',
             headers={"Content-Type": "application/json; charset=utf-8"},
             json={


### PR DESCRIPTION
为国内服务器无法直连discord但又不想在服务器上挂代理的提供一种方式，已经过本地与Tencent cloud广州地区服务器测试，其余地区暂未测试
